### PR TITLE
Howling Blaster typo fix

### DIFF
--- a/mods/digimon/moves.js
+++ b/mods/digimon/moves.js
@@ -1132,7 +1132,7 @@ let BattleMovedex = {
 		secondary: {
 			chance: 50,
 			self: {
-				boosts: { spd: 2 },
+				boosts: { spe: 2 },
 			},
 		},
 		target: "any",


### PR DESCRIPTION
The move had spd as the boost instead of the correct spe. I our games source paperwork to be sure so i've fixed the error.