### PR TITLE
Meicrackmon Vicious Mode had the wrong Signature

### DIFF
--- a/mods/digimon/learnsets.js
+++ b/mods/digimon/learnsets.js
@@ -1648,7 +1648,7 @@ let BattleLearnsets = {
 			shadowfall: ["7M"],
 			evilsquall: ["7M"],
 			blackout: ["7M"],
-			modestlystun: ["7M"],
+			berserkthinking: ["7M"],
 			protect: ["7M"],
 		},
 	},


### PR DESCRIPTION
It had regular meicrackmon's signature, not sure how that happened.