### PR TITLE
Filth Attack Buffs

### DIFF
--- a/mods/digimon/moves.js
+++ b/mods/digimon/moves.js
@@ -5477,14 +5477,14 @@ let BattleMovedex = {
 			volatileStatus: 'flinch',
 		},
 	},
-	"pooptoss": {
-		accuracy: 95,
-		basePower: 35,
+	"guerrillapoop": {
+		accuracy: 80,
+		basePower: 95,
 		category: "Physical",
 		desc: "Next turn the target can't use status moves.",
 		shortDesc: "Next turn the target can't use status moves.",
 		id: "pooptoss",
-		name: "Poop Toss",
+		name: "Guerrilla Poop",
 		num: -315,
 		signature: false,
 		priority: 0,
@@ -5507,7 +5507,7 @@ let BattleMovedex = {
 		num: -316,
 		signature: false,
 		id: "poopattackfield",
-		basePower: 50,
+		basePower: 80,
 		priority: 0,
 		pp: 20,
 		category: "Special",
@@ -5534,7 +5534,7 @@ let BattleMovedex = {
 		num: -317,
 		signature: false,
 		id: "poopfling",
-		basePower: 15,
+		basePower: 18,
 		priority: 0,
 		pp: 30,
 		category: "Physical",
@@ -5555,11 +5555,11 @@ let BattleMovedex = {
 			if (this.random(100) < 5) target.addVolatile('confusion', source);
 		},
 	},
-	"guerrillapoop": {
-		name: "Guerrilla Poop",
+	"pooptoss": {
+		name: "Poop Toss",
 		num: -318,
 		signature: false,
-		id: "guerrillapoop",
+		id: "bigpooptoss",
 		basePower: 75,
 		priority: 0,
 		pp: 15,
@@ -5591,8 +5591,8 @@ let BattleMovedex = {
 		category: "Special",
 		type: "Filth",
 		target: "allAdjacentFoes",
-		desc: "20% lower foe(s) Speed by 1. 5% chance of flinch. 10% chance of poison. Hits all adjacent foes.",
-		shortDesc: "20% chance -1 spe. 5% flinch. 10% psn.",
+		desc: "25% lower foe(s) Speed by 1. 5% chance of flinch. 10% chance of poison. Hits all adjacent foes.",
+		shortDesc: "25% chance -1 spe. 5% flinch. 10% psn.",
 		onPrepareHit(target, source, move) {
 			this.attrLastMove('[still]');
 			this.add('-anim', source, "nastyplot", source);
@@ -5610,7 +5610,7 @@ let BattleMovedex = {
 				volatileStatus: 'flinch',
 			},
 			{
-				chance: 20,
+				chance: 25,
 				boosts: { spe: -1 },
 			},
 		],


### PR DESCRIPTION
I accidentally buffed up the poop attack in my notes, They actually need this anyways as they are really under powered and it was feedback during digi-day anyways. So I guess sometimes a mistake could be for the better.

List of changes due to rebalancing

Poop Toss and Guerrilla Poop have had a name swap. No Effect changes but BP has been buffed which is stated below.

Guerrilla Poop now has a BP of 95. The New Guerrilla Poop also has a acc of 80 now to make up for the boost.

Poop Fling now has a BP of 18

Extreme Poop Death now has a 25% chance of doing its effect instead of 20 due to the BP being a bit lower then Guerrilla Poop.