### PR TITLE
Gave Piximon DG-Fairy Typing

### DIFF
--- a/mods/digimon/pokedex.js
+++ b/mods/digimon/pokedex.js
@@ -1722,7 +1722,7 @@ let BattlePokedex = {
 		num: -2132,
 		name: "Piximon",
 		stage: "Ultimate",
-		types: ["DG-Electric"],
+		types: ["DG-Electric", "DG-Fairy"],
 		gender: "N",
 		baseStats: {hp: 118, atk: 65, def: 63, spa: 64, spd: 63, spe: 65},
 		abilities: {0: "Data"},


### PR DESCRIPTION
Piximon is now DG-Electric and DG-Fairy, the updated picture for its icon has already been sent to main.