### PR TITLE
Thunder Justice Debuff

### DIFF
--- a/mods/digimon/moves.ts
+++ b/mods/digimon/moves.ts
@@ -1009,8 +1009,8 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	},
 	"thunderjustice": {
 		num: -143,
-		accuracy: 90,
-		basePower: 150,
+		accuracy: 70,
+		basePower: 110,
 		category: "Special",
 		desc: "20% Paralyze the target, plus Fairy Damage in calculation.",
 		shortDesc: "20% PAR the Target + Fairy DMG.",

--- a/mods/digimon/moves.ts
+++ b/mods/digimon/moves.ts
@@ -1016,7 +1016,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		shortDesc: "20% PAR the Target + Fairy DMG.",
 		id: "thunderjustice",
 		name: "Thunder Justice",
-		pp: 5,
+		pp: 10,
 		priority: 0,
 		onPrepareHit(target, source, move) {
 			this.attrLastMove('[still]');


### PR DESCRIPTION
The move was originally a charging move that was 90% acc so it had 150BP. I coded it like thunder by accident so I have now fixed it to be as powerful as thunder as thats more fun.