### PR TITLE
Goburimon had Pokemon moves???

### DIFF
--- a/mods/digimon/digimon-sets.ts
+++ b/mods/digimon/digimon-sets.ts
@@ -429,7 +429,7 @@ export default [
     {
         "species": "Goburimon",
 		"universe":"Digimon",
-        "moves": ["Dynamite Kick", "Awesome Quake", "Facade", "Spiral Driver", "Mach Jab", "Headbutt", "Heat Breath", "Fire Tower", "Fighting Aura", "Agility", "Focus Energy", "Growl", "Leer", "Mirror Move", "Protect", "Rest", "Roost", "Substitute", "Toxic"],    
+        "moves": ["Dynamite Kick", "Awesome Quake", "Facade", "Spiral Driver", "Mach Jab", "Headbutt", "Heat Breath", "Fire Tower", "Fighting Aura", "Speed Break Field", "Acceleration Boost", "Attack Break Field", "Guard Break Field", "Mirror Reflection", "Protect", "Rest", "Final Heal", "Substitute", "Toxic"],    
 	},
     {
         "species": "Gotsumon",


### PR DESCRIPTION
Goburimons moveset was not a full conversion. I have fixed this. If odd moves show up again check the digipedia and make sure they match.